### PR TITLE
Add proper percent encoding/decoding to Query.pairs_

### DIFF
--- a/src/Freya.Types.Uri/Types.fs
+++ b/src/Freya.Types.Uri/Types.fs
@@ -514,11 +514,21 @@ type Query =
                 i = 0x3d // =
              || i = 0x26 // &
 
+        let predicate i =
+             isPchar i
+          || isEqualsOrAmpersand i
+
+        let decoder =
+          Encoding.Percent.decoder ()
+
+        let encoder =
+          Encoding.Percent.encoder predicate
+
         let pairPartV =
-            manySatisfy (int >> isEqualsOrAmpersand >> not)
+            manySatisfy (int >> isEqualsOrAmpersand >> not) |>> decoder
 
         let pairPartP =
-            manySatisfy (int >> isEqualsOrAmpersand >> not)
+            manySatisfy (int >> isEqualsOrAmpersand >> not) |>> decoder
 
         let pairP =
             pairPartP .>>. opt(( skipChar '=') >>. ( pairPartV))
@@ -529,7 +539,7 @@ type Query =
             sepBy1 pairP skipAmp
         
         let pairF =
-            function | (k, Some v) -> Formatting.append k >> Formatting.append "=" >> Formatting.append v
+            function | (k, Some v) -> Formatting.append (encoder k) >> Formatting.append "=" >> Formatting.append (encoder v)
                      | (k, None) -> Formatting.append k
 
         let pairsF =

--- a/tests/Freya.Types.Uri.Tests/Types.fs
+++ b/tests/Freya.Types.Uri.Tests/Types.fs
@@ -165,10 +165,37 @@ let ``Uri Formatting/Parsing`` () =
 
 [<Fact>]
 let ``Query Parse With Encoded Equals`` () =
-    let expectedResult = Some [ "one", Some ("two%3d") ]
+    let expectedResult = Some [ "one", Some ("two=") ]
     let query = Query.parse "one=two%3d"
     let queryPairs = query |> fst Query.pairs_
     Assert.Equal (expectedResult, queryPairs)
+
+[<Fact>]
+let ``Query Parse With Encoded Slash Value`` () =
+    let expectedResult = Some [ "one", Some ("two/") ]
+    let query = Query.parse "one=two%2f"
+    let queryPairs = query |> fst Query.pairs_
+    Assert.Equal (expectedResult, queryPairs)
+
+[<Fact>]
+let ``Query Parse With Encoded Slash Key`` () =
+    let expectedResult = Some [ "one/", Some ("two") ]
+    let query = Query.parse "one%2f=two"
+    let queryPairs = query |> fst Query.pairs_
+    Assert.Equal (expectedResult, queryPairs)
+
+[<Fact>]
+let ``Query Pairs Formats With Restricted Characters`` () =
+    let expectedResult = "one%3F=two%2Fthree%3F"
+    let queryPairs = ["one?", Some("two/three?")]
+    let query = (snd Query.pairs_) queryPairs |> string
+    Assert.Equal (expectedResult, query)
+
+[<Fact>]
+let ``Query Round Trip With Restricted Characters`` () =
+    let expectedResult = ["one", Some("two/three?")]
+    let queryPairs = (snd Query.pairs_) expectedResult |> (fst Query.pairs_)
+    Assert.Equal (Some expectedResult, queryPairs)
 
 [<Fact>]
 let ``Query Pairs``() =


### PR DESCRIPTION
* Handle encode/decode of pair key/values.
* Add tests for various cases.

Note: This did make a change to an existing test, that expected the pairs to come back w/ the values still percent encoded. To me... this seems counter intuitive. I would expect to get back pairs that are decoded and have the intended values as sent by the user agent.