### PR TITLE
Proper matching of URI Templates against query values w/ subdelimiters

### DIFF
--- a/src/Freya.Types.Uri.Template/Types.fs
+++ b/src/Freya.Types.Uri.Template/Types.fs
@@ -269,6 +269,33 @@ type UriTemplate =
         let idP =
             preturn ()
 
+        let isSubDelimSubset i =
+             i = 0x21 // !
+          || i = 0x24 // $
+          || i = 0x27 // '
+          || i = 0x28 // (
+          || i = 0x29 // )
+          || i = 0x2A // *
+          || i = 0x2B // +
+          || i = 0x3B // ;
+
+        let isPcharSubset i =
+             Grammar.isUnreserved i
+          || isSubDelimSubset i
+          || i = 0x40 // @
+          || i = 0x3a // :
+
+        let isQuery i =
+             isPcharSubset i
+          || i = 0x2F // /
+          || i = 0x3F // ?
+
+        let queryP =
+            let parser = Encoding.Percent.parser isQuery
+            let decoder = Encoding.Percent.decoder ()
+
+            parser |>> decoder
+
         let simpleP =
             let parser = Encoding.Percent.parser Grammar.isUnreserved
             let decoder = Encoding.Percent.decoder ()
@@ -349,9 +376,9 @@ type UriTemplate =
 
         let mapVar key separator =
             function | Some (Level3 Query), Some (Level4 Explode)
-                     | Some (Level3 QueryContinuation), Some (Level4 Explode) -> namedExplodedListOrKeysP simpleP separator key
+                     | Some (Level3 QueryContinuation), Some (Level4 Explode) -> namedExplodedListOrKeysP queryP separator key
                      | Some (Level3 Query), _
-                     | Some (Level3 QueryContinuation), _ -> namedP simpleP key
+                     | Some (Level3 QueryContinuation), _ -> namedP queryP key
                      | Some (Level2 _), Some (Level4 Explode) -> listOrKeysP reservedP separator key
                      | _, Some (Level4 Explode) -> listOrKeysP simpleP separator key
                      | Some (Level2 _), _ -> atomP reservedP key

--- a/tests/Freya.Types.Uri.Template.Tests/Types.fs
+++ b/tests/Freya.Types.Uri.Template.Tests/Types.fs
@@ -256,6 +256,7 @@ let ``Query Expansion Renders Correctly`` () =
 [<Fact>]
 let ``Query Expansion Matches Correctly`` () =
     matches "/test{?who}" "/test?who=fred" [ Key "who", Atom "fred" ]
+    matches "/test{?who}" "/test?who=fred/wilma" [ Key "who", Atom "fred/wilma" ]
     matches "/test{?x,y}" "/test?x=1024&y=768" [ Key "x", Atom "1024"; Key "y", Atom "768" ]
     matches "/test{?x,y,empty}" "/test?x=1024&y=768&empty=" [ Key "x", Atom "1024"; Key "y", Atom "768"; Key "empty", Atom "" ]
     matches "/test{?list}" "/test?list=red,green,blue" [ Key "list", List [ "red"; "green"; "blue" ] ]
@@ -272,6 +273,8 @@ let ``Query Expansion Matches Correctly`` () =
     matches "/test{?list*}" "/test?" []
     matches "/test{?list*}" "/test?&" []
     matches "/test{?list*}" "/test?list" [ Key "list", List [""] ]
+    matches "/test{?list*}" "/test?path=foo/bar" [ Key "list", Keys [ ("path", "foo/bar") ] ]
+    matches "/test{?list*}" "/test?path=?;+/*()" [ Key "list", Keys [ ("path", "?;+/*()") ] ]
     //matches "/test{?list*}" "/test?list&" [ Key "list", List [""] ]
     matches "/test{?list*}" "/test?list=" [ Key "list", List [""] ]
     //matches "/test{?list*}" "/test?list=&" [ Key "list", List [""] ]


### PR DESCRIPTION
* Properly match query values that include a subset of the sub-delims
  from the URI spec. Excludes ',' and '&' since those are used for
  splitting key/value pairs and value lists in URI Templates.

I hit this issue recently when implementing an OAuth 2.0 redirect URI w/ Google OAuth, and it redirected with a `code` value that included a `/` but Freya wouldn't match on it and kept returning a 404 because the URI Template failed to match.